### PR TITLE
Size shouldnt be twice as large as the defined size

### DIFF
--- a/src/gazebo_ros_gridmap.cpp
+++ b/src/gazebo_ros_gridmap.cpp
@@ -276,7 +276,7 @@ void GazeboRosGridmap::create_gridmap()
 
   impl_->gridmap_.setFrameId("map");
   impl_->gridmap_.setGeometry(
-    grid_map::Length(size_x * 2.0, size_y * 2.0), resolution,
+    grid_map::Length(size_x, size_y), resolution,
     grid_map::Position(center_x, center_y));
 
   gazebo::physics::PhysicsEnginePtr engine = impl_->world_->Physics();
@@ -286,8 +286,9 @@ void GazeboRosGridmap::create_gridmap()
     engine->CreateShape("ray", gazebo::physics::CollisionPtr()));
 
   // Surface
-  for (double x = min_x; x < max_x; x += resolution) {
-    for (double y = min_y; y < max_y; y += resolution) {
+  for (double x = min_x + resolution; x < max_x; x += resolution) {
+    for (double y = min_y + resolution; y < max_y; y += resolution) {
+
       ignition::math::Vector3d point(x, y, 0);
       impl_->gridmap_.atPosition("elevation", grid_map::Position(x, y)) =
         get_surface(point, min_z, max_z, resolution, ray);
@@ -297,8 +298,8 @@ void GazeboRosGridmap::create_gridmap()
   std::cout << "Surface completed " << std::endl;
 
   // Obstacles
-  for (double x = min_x; x < max_x; x += resolution) {
-    for (double y = min_y; y < max_y; y += resolution) {
+  for (double x = min_x + resolution; x < max_x - resolution; x += resolution) {
+    for (double y = min_y + resolution; y < max_y - resolution; y += resolution) {
       ignition::math::Vector3d point(x, y, 0);
       double surface = impl_->gridmap_.atPosition("elevation", grid_map::Position(x, y));
       if (is_obstacle(point, surface, min_height, max_height, resolution, ray)) {

--- a/src/gazebo_ros_gridmap.cpp
+++ b/src/gazebo_ros_gridmap.cpp
@@ -286,10 +286,10 @@ void GazeboRosGridmap::create_gridmap()
     engine->CreateShape("ray", gazebo::physics::CollisionPtr()));
 
   // Surface
-  
   // iterate the gridmap and fill each cell
-  for (grid_map::GridMapIterator grid_iterator(impl_->gridmap_);  !grid_iterator.isPastEnd(); ++grid_iterator) {
-  
+  for (grid_map::GridMapIterator grid_iterator(impl_->gridmap_); !grid_iterator.isPastEnd();
+    ++grid_iterator)
+  {
     // get the value at the iterator
     grid_map::Position current_pos;
     impl_->gridmap_.getPosition(*grid_iterator, current_pos);
@@ -297,16 +297,13 @@ void GazeboRosGridmap::create_gridmap()
 
     // get the height at this point
     impl_->gridmap_.atPosition("elevation", current_pos) =
-        get_surface(point, min_z, max_z, resolution, ray);
-
+      get_surface(point, min_z, max_z, resolution, ray);
   }
 
   std::cout << "Surface completed " << std::endl;
 
   // Obstacles
-
-  for (grid_map::GridMapIterator obs_it(impl_->gridmap_);  !obs_it.isPastEnd(); ++obs_it) {
-  
+  for (grid_map::GridMapIterator obs_it(impl_->gridmap_); !obs_it.isPastEnd(); ++obs_it) {
     // get the value at the iterator
     grid_map::Position current_pos;
     impl_->gridmap_.getPosition(*obs_it, current_pos);
@@ -315,11 +312,9 @@ void GazeboRosGridmap::create_gridmap()
     double surface = impl_->gridmap_.atPosition("elevation", current_pos);
     if (is_obstacle(point, surface, min_height, max_height, resolution, ray)) {
       impl_->gridmap_.atPosition("occupancy", current_pos) = 254;
+    } else {
+      impl_->gridmap_.atPosition("occupancy", current_pos) = 1.0;  // free space
     }
-    else{
-      impl_->gridmap_.atPosition("occupancy", current_pos) = 1.0; // free space
-    }
-
   }
 
   std::cout << "Obstacles completed " << std::endl;

--- a/src/gazebo_ros_gridmap.cpp
+++ b/src/gazebo_ros_gridmap.cpp
@@ -286,26 +286,40 @@ void GazeboRosGridmap::create_gridmap()
     engine->CreateShape("ray", gazebo::physics::CollisionPtr()));
 
   // Surface
-  for (double x = min_x + resolution; x < max_x; x += resolution) {
-    for (double y = min_y + resolution; y < max_y; y += resolution) {
+  
+  // iterate the gridmap and fill each cell
+  for (grid_map::GridMapIterator grid_iterator(impl_->gridmap_);  !grid_iterator.isPastEnd(); ++grid_iterator) {
+  
+    // get the value at the iterator
+    grid_map::Position current_pos;
+    impl_->gridmap_.getPosition(*grid_iterator, current_pos);
+    ignition::math::Vector3d point(current_pos.x(), current_pos.y(), 0);
 
-      ignition::math::Vector3d point(x, y, 0);
-      impl_->gridmap_.atPosition("elevation", grid_map::Position(x, y)) =
+    // get the height at this point
+    impl_->gridmap_.atPosition("elevation", current_pos) =
         get_surface(point, min_z, max_z, resolution, ray);
-    }
+
   }
 
   std::cout << "Surface completed " << std::endl;
 
   // Obstacles
-  for (double x = min_x + resolution; x < max_x - resolution; x += resolution) {
-    for (double y = min_y + resolution; y < max_y - resolution; y += resolution) {
-      ignition::math::Vector3d point(x, y, 0);
-      double surface = impl_->gridmap_.atPosition("elevation", grid_map::Position(x, y));
-      if (is_obstacle(point, surface, min_height, max_height, resolution, ray)) {
-        impl_->gridmap_.atPosition("occupancy", grid_map::Position(x, y)) = 254;
-      }
+
+  for (grid_map::GridMapIterator obs_it(impl_->gridmap_);  !obs_it.isPastEnd(); ++obs_it) {
+  
+    // get the value at the iterator
+    grid_map::Position current_pos;
+    impl_->gridmap_.getPosition(*obs_it, current_pos);
+    ignition::math::Vector3d point(current_pos.x(), current_pos.y(), 0);
+
+    double surface = impl_->gridmap_.atPosition("elevation", current_pos);
+    if (is_obstacle(point, surface, min_height, max_height, resolution, ray)) {
+      impl_->gridmap_.atPosition("occupancy", current_pos) = 254;
     }
+    else{
+      impl_->gridmap_.atPosition("occupancy", current_pos) = 1.0; // free space
+    }
+
   }
 
   std::cout << "Obstacles completed " << std::endl;


### PR DESCRIPTION
Working with this plugin, I realized it creates a grid_map msg twice as large as needed, leaving the space that is not scanned empty.

I reduced the grid_map size to the size required by the parameters, and I spaced the `min_xy` and `max_xy` with the `resolution` to avoid the out-of-range error thrown when accessing the grid_map. 

Nevertheless, the first row and column still empty. It needs a more precise review.

Here I show an example map created from the elevation layer from the grid_map of the plugin. The empty cells are transparent. 

### Before the changes:

![ele_map_1656445015](https://user-images.githubusercontent.com/22964725/176284004-b0127dfb-ff1f-4dab-8603-863e8b247e47.png)

### After the changes:
![ele_resol_changes](https://user-images.githubusercontent.com/22964725/176283787-370b34c6-d139-4aa6-8fd2-0c68b0386528.png)

Signed-off-by: ivrolan <ivanlpzbrc01@gmail.com>