### PR TITLE
Obstacle in the octomap

### DIFF
--- a/src/gazebo_ros_gridmap.cpp
+++ b/src/gazebo_ros_gridmap.cpp
@@ -429,7 +429,7 @@ void GazeboRosGridmap::create_octomap()
 
   std::cout << "Octomap completed" << std::endl;
 
-  //filter octomap
+  // filter octomap
   // iterate the gridmap and set the elevation as max Z possible
   for (grid_map::GridMapIterator grid_iterator(impl_->gridmap_); !grid_iterator.isPastEnd();
     ++grid_iterator)

--- a/src/gazebo_ros_gridmap.cpp
+++ b/src/gazebo_ros_gridmap.cpp
@@ -261,21 +261,15 @@ bool GazeboRosGridmap::is_obstacle(
   std::string entity;
   double dist;
 
-  for (double z = min_z; z < max_z; z = z + resolution) {
-    start_point.X() = central_point.X() - resolution / 2.0;
-    start_point.Y() = central_point.Y();
-    start_point.Z() = surface + z;
+  start_point.Z() = surface + min_z;
 
-    end_point.X() = end_point.X() - resolution / 2.0;
-    start_point.Y() = central_point.Y();
-    start_point.Z() = surface + z;
+  end_point.Z() = surface + max_z;
 
-    ray->SetPoints(start_point, end_point);
-    ray->GetIntersection(dist, entity);
+  ray->SetPoints(start_point, end_point);
+  ray->GetIntersection(dist, entity);
 
-    if (dist < resolution) {
-      return true;
-    }
+  if (dist < max_z - min_z) {
+    return true;
   }
 
   return false;

--- a/worlds/gazebo_ros_gridmap.world
+++ b/worlds/gazebo_ros_gridmap.world
@@ -829,13 +829,14 @@
       </ros>
       <center_x>0.0</center_x>
       <center_y>0.0</center_y>
+      <center_z>0.05</center_z>
       <min_scan_x>-10.0</min_scan_x>
       <min_scan_y>-10.0</min_scan_y>
       <min_scan_z>-10.0</min_scan_z>
       <max_scan_x>10.0</max_scan_x>
       <max_scan_y>10.0</max_scan_y>
       <max_scan_z>10.0</max_scan_z>
-      <min_height>0.2</min_height>
+      <min_height>0.1</min_height>
       <max_height>1.5</max_height>
       <resolution>0.1</resolution>
     </plugin>

--- a/worlds/gazebo_ros_gridmap_apollo.world
+++ b/worlds/gazebo_ros_gridmap_apollo.world
@@ -572,9 +572,9 @@
       <max_scan_x>30.0</max_scan_x>
       <max_scan_y>30.0</max_scan_y>
       <max_scan_z>10.0</max_scan_z>
-      <min_height>1.0</min_height>
+      <min_height>0.12</min_height>
       <max_height>2.0</max_height>
-      <resolution>0.50</resolution>
+      <resolution>0.2</resolution>
     </plugin>
   </world>
 </sdf>


### PR DESCRIPTION
This PR filters all the octomap nodes and deletes the ones below or at surface level. 

Also some problems with the obstacle layer in the grid_map were detected. The function `is_obstacle()`started the raycasting from z=0,. Changed the function to raycast only 1 ray from `z = surface + min_height` to `z= surface + max_height` and return true if `dist < max_height - min_height`.

Additionally, some parameters of the maps were changed (e.g. min_height was lowered to show the robot in the apollo world)

Cheers,
Iván López Broceño